### PR TITLE
some enhancements

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,6 +62,12 @@ if proxy_protocol and proxy_host and proxy_port:
 name = config.get('name', '')
 private_mode = config.get('private_mode', False)
 private_whitelist = config.get('private_whitelist', [])
+private_mode_strict = False
+private_whitelist_strict = None
+if isinstance(private_mode, str) and private_mode.lower() == 'strict':
+    private_mode = True
+    private_mode_strict = True
+    private_whitelist_strict = private_whitelist
 
 random_mode = config.get('random_mode', False)
 
@@ -191,7 +197,7 @@ async def download_history(min_id, max_id):
         await bot.send_message(admin_id, '下载完成')
 
 
-@bot.on(events.CallbackQuery())
+@bot.on(events.CallbackQuery(chats=private_whitelist_strict))
 async def bot_callback_handler(event):
     if event.data and event.data != b'-1':
         page_num = int(event.data)
@@ -207,7 +213,7 @@ async def bot_callback_handler(event):
     await event.answer()
 
 
-@bot.on(events.NewMessage())
+@bot.on(events.NewMessage(chats=private_whitelist_strict))
 async def bot_message_handler(event):
     try:
         text = event.raw_text

--- a/main.py
+++ b/main.py
@@ -48,14 +48,16 @@ page_len = config.get('search', {}).get('page_len', 10)
 welcome_message = config.get('welcome_message', 'Welcome')
 
 proxy_protocol = config.get('proxy', {}).get('protocol', None)
-assert proxy_protocol in ('socks5', 'socks4', 'http')
+assert proxy_protocol in ('socks5', 'socks4', 'http', None)
 proxy_host = config.get('proxy', {}).get('host', None)
 proxy_port = config.get('proxy', {}).get('port', None)
 
 runtime_dir = Path(config.get('runtime_dir', '.'))
 
 proxy = None
-if proxy_protocol and proxy_host and proxy_port:
+if not proxy_protocol and (proxy_host or proxy_port):
+    logging.warning('Proxy protocol unspecified, proxy will not be enabled')
+elif proxy_protocol and proxy_host and proxy_port:
     proxy = (proxy_protocol, proxy_host, proxy_port)
 
 

--- a/searcher.yaml.example
+++ b/searcher.yaml.example
@@ -22,7 +22,7 @@ search:
 
 welcome_message: 这里是 @sharzy_talk 的搜索 Bot，直接发送你要搜索的内容即可  # 用户启动 bot 时的欢迎信息
 
-private_mode: false  # 如果设置为 true，那么人们将无法看到消息的预览
+private_mode: false  # 如果设置为 true，那么人们将无法看到消息的预览；如果设置为 strict，那么只有白名单内的用户才能操作 bot (请把自己加进白名单内)
 
 private_whitelist:  # private mode 的白名单，在此名单中的用户总可以看到消息的预览
   - 134312541


### PR DESCRIPTION
### feat: set bot command on start

set bot command(s) on start only for admin. raise a critical error and exit if admin have not had a conversation with the bot. (previously, if so, a `ValueError` will remain uncaught and lead the bot to exit as well)

### feat: new option `strict` for `privacy_mode`

only those who in the white list can get responds from the bot, others will be ignored

### fix: `proxy_protocol` cannot be none
